### PR TITLE
Adding rule to keep simple lambdas in one line

### DIFF
--- a/intellij-java-xl-style.xml
+++ b/intellij-java-xl-style.xml
@@ -383,6 +383,7 @@
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
     <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+    <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
     <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />


### PR DESCRIPTION
Adding `<option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />`

This is so that whenever hitting auto-indent, the styleguide doesn't change the block of code, adding a linebreak.

`.subscribe(o -> {});` 
`Runnable r = () -> {};`
will stay that way 
instead of: 
`Runnable r = () -> {\n};`
`.subscribe(o -> {\n});`